### PR TITLE
[feature] Filter active tasks: Assigned to me

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -192,7 +192,7 @@ event.on_runtime_mod_setting_changed(function(e)
       end
       TasksGui.refs.new_task_button.tooltip = tooltip
     end
-  elseif e.setting == "tlst-show-active-task" then
+  elseif e.setting == "tlst-show-active-task" or e.setting == "tlst-active-filter-assigned" then
     local player = game.get_player(e.player_index) --[[@as LuaPlayer]]
     local player_table = global.players[e.player_index]
     local value = player.mod_settings["tlst-show-active-task"].value

--- a/locale/en/TaskList.cfg
+++ b/locale/en/TaskList.cfg
@@ -10,6 +10,7 @@ tlst-new-tasks-at-top=Automatically add new tasks to the top
 tlst-new-task-on-confirm=Open new task window on confirm
 tlst-new-tasks-in-progress=Automatically mark new tasks as in progress
 tlst-show-active-task=Show active task [img=info]
+tlst-active-filter-assigned=Filter active tasks: Assigned to me
 
 [gui]
 tlst-add-subtask= +  Subtask

--- a/locale/ru/TaskList.cfg
+++ b/locale/ru/TaskList.cfg
@@ -7,6 +7,7 @@ tlst-show-active-task=Показывать активную задачу [img=in
 tlst-new-tasks-at-top=Добавлять новые задачи в начало списка
 tlst-new-task-on-confirm=Открывать окно новой задачи при подтверждении
 tlst-new-tasks-in-progress=Помечать новые задачи как "Выполняется"
+tlst-active-filter-assigned=Фильтровать активные задачи: Назначенные мне
 
 [mod-setting-description]
 tlst-show-active-task=Активная задача будет отображаться в самом начале списка, со статусом "Выполняется" (не подзадача).

--- a/scripts/gui/active-task-button.lua
+++ b/scripts/gui/active-task-button.lua
@@ -24,6 +24,26 @@ function active_task_button.build(player, player_table)
 end
 
 --- @param player LuaPlayer
+--- @param task Task
+--- @return bool
+local function can_show_task(player, Task)
+  if not Task then
+    return false
+  end
+  if Task.status ~= "in_progress" then
+    return false
+  end
+  if player.mod_settings["tlst-active-filter-assigned"].value then
+    if Task.assignee == nil then
+      return false
+    end
+    return Task.assignee.index == player.index
+  end
+
+  return true
+end
+
+--- @param player LuaPlayer
 --- @param player_table PlayerTable
 function active_task_button.update(player, player_table)
   local button = player_table.guis.active_task_button
@@ -37,7 +57,7 @@ function active_task_button.update(player, player_table)
     -- The "active" task is the first top-level active task we come across
     for _, task_id in pairs(tasks) do
       local Task = global.tasks[task_id]
-      if Task and Task.status == "in_progress" then
+      if can_show_task(player, Task) then
         button.caption = Task.title
         return
       end

--- a/scripts/gui/active-task-button.lua
+++ b/scripts/gui/active-task-button.lua
@@ -25,7 +25,7 @@ end
 
 --- @param player LuaPlayer
 --- @param Task Task
---- @return bool
+--- @return boolean
 local function can_show_task(player, Task)
   if not Task then
     return false

--- a/scripts/gui/active-task-button.lua
+++ b/scripts/gui/active-task-button.lua
@@ -24,7 +24,7 @@ function active_task_button.build(player, player_table)
 end
 
 --- @param player LuaPlayer
---- @param task Task
+--- @param Task Task
 --- @return bool
 local function can_show_task(player, Task)
   if not Task then

--- a/settings.lua
+++ b/settings.lua
@@ -4,6 +4,21 @@ data:extend({
     name = "tlst-new-task-on-confirm",
     setting_type = "runtime-per-user",
     default_value = false,
+    order = "1",
+  },
+  {
+    type = "bool-setting",
+    name = "tlst-new-tasks-at-top",
+    setting_type = "runtime-per-user",
+    default_value = false,
+    order = "2",
+  },
+  {
+    type = "bool-setting",
+    name = "tlst-new-tasks-in-progress",
+    setting_type = "runtime-per-user",
+    default_value = false,
+    order = "3",
   },
   {
     type = "string-setting",
@@ -11,12 +26,13 @@ data:extend({
     setting_type = "runtime-per-user",
     allowed_values = { "off", "force", "private" },
     default_value = "off",
+    order = "4",
   },
   {
     type = "bool-setting",
-    name = "tlst-new-tasks-in-progress",
+    name = "tlst-active-filter-assigned",
     setting_type = "runtime-per-user",
     default_value = false,
+    order = "5",
   },
-  { type = "bool-setting", name = "tlst-new-tasks-at-top", setting_type = "runtime-per-user", default_value = false },
 })


### PR DESCRIPTION
Partially solves #20.

I've made a boolean setting for only showing tasks that are assigned to the current player in the Active task button. I made it a separate option for the sake of extensibility, in case there will be more filtering options in the future.

Also added some `order` values to settings, hope you don't mind (otherwise the order seemed very random)